### PR TITLE
Fix motion interpolation

### DIFF
--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -571,6 +571,9 @@ if __name__ == "__main__":
                             if motion_params["apply"]:
                                 recording_processed = recording_corrected
                                 recording_bin = recording_bin_corrected
+                                # if motion is applied, the recording is no longer json serializable since
+                                # it contains the motion object which is not json serializable
+                                visualization_file_is_json_serializable = False
                         else:
                             logging.info(f"\tMotion computation failed. Skipping motion correction")
                             preprocessing_notes += "\n- Motion computation failed. Skipping motion correction.\n"

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -569,7 +569,6 @@ if __name__ == "__main__":
                                     recording_bin_corrected = si.append_recordings(rec_corrected_bin_list)
 
                             if motion_params["apply"]:
-                                logging.info(f"\tApplying motion correction")
                                 recording_processed = recording_corrected
                                 recording_bin = recording_bin_corrected
                         else:


### PR DESCRIPTION
Fixes serialization of motion-interpolated object, which needs to be serialized to pickle instead of JSON for proper reloading downstream, since it contains the `Motion` object